### PR TITLE
adds configuration, option to support lids - 1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ one_deserialized = JSONApi::Deserializer.new(response).deserialized_hash
 # one_deserialized.name == 'fluffy'
 ```
 
+## Configuration
+
+Version 1.3.1 introduces the ability to configure the gem using an initializer file and block with following options:
+
+```
+JSONApi::Deserializer.configure do |config|
+  config.supports_lids = true
+end
+```
+
+Above are all options for configuration with the default of each configuration option.
+
+`supports_lids` - will include a `lid` key in each deserialized hash record. See JSONAPI spec '> 1.1' for more information on lids.
 
 ## Development
 

--- a/jsonapi_deserializer.gemspec
+++ b/jsonapi_deserializer.gemspec
@@ -2,6 +2,7 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'jsonapi_deserializer/version'
+require 'jsonapi_deserializer/configuration'
 
 Gem::Specification.new do |spec|
   spec.name          = "jsonapi_deserializer"

--- a/lib/jsonapi_deserializer/configuration.rb
+++ b/lib/jsonapi_deserializer/configuration.rb
@@ -1,0 +1,23 @@
+module JSONApi
+  class Deserializer
+    class << self
+      attr_accessor :configuration
+    end
+
+    def self.configuration
+      @configuration ||= Configuration.new
+    end
+
+    def self.configure
+      yield(configuration)
+    end
+
+    class Configuration
+      attr_accessor :support_lids
+
+      def initialize
+        @support_lids = true
+      end
+    end
+  end
+end

--- a/lib/jsonapi_deserializer/version.rb
+++ b/lib/jsonapi_deserializer/version.rb
@@ -1,5 +1,5 @@
 module JSONApi
   class Deserializer
-    VERSION = "1.3.0"
+    VERSION = "1.3.1"
   end
 end

--- a/spec/jsonapi_deserializer_configuration_spec.rb
+++ b/spec/jsonapi_deserializer_configuration_spec.rb
@@ -1,0 +1,125 @@
+require 'spec_helper'
+
+describe JSONApi::Deserializer::Configuration do
+  let(:payload_with_lids) do
+    {
+      data: {
+        type: 'dogs',
+        id: '1',
+        lid: '1',
+        relationships: {
+          owner: {
+            data: {
+              lid: '1',
+              type: 'users',
+              color: 'grey'
+            }
+          }
+        }
+      },
+      included: [
+        {
+          type: 'users',
+          lid: '1',
+          attributes: {
+            name: 'Amorcito'
+          }
+        }
+      ]
+    }
+  end
+
+  let(:payload_no_lids) do
+    {
+      data: {
+        type: 'dogs',
+        id: '1',
+        relationships: {
+          owner: {
+            data: {
+              type: 'users',
+              color: 'grey'
+            }
+          }
+        }
+      },
+      included: [
+        {
+          type: 'users',
+          attributes: {
+            id: '1',
+            name: 'Amorcito'
+          }
+        }
+      ]
+    }
+  end
+
+  subject { JSONApi::Deserializer.new(payload_with_lids).deserialized_hash }
+
+  describe 'support_lids option' do
+    context 'default option - true' do
+      it 'is the default' do
+        expect(JSONApi::Deserializer.configuration.support_lids).to eq(true)
+      end
+
+      it 'includes lid property deserialized hash' do
+        expect(subject.keys).to contain_exactly('id', 'lid', 'owner')
+        expect(subject.owner.keys).to contain_exactly('id', 'lid', 'name')
+
+        expect(subject.lid).to eq('1')
+        expect(subject.owner.lid).to eq('1')
+      end
+    end
+
+    context 'option - false' do
+      before do
+        JSONApi::Deserializer.configure do |config|
+          config.support_lids = false
+        end
+      end
+
+      after do
+        JSONApi::Deserializer.configure do |config|
+          config.support_lids = true
+        end
+      end
+
+      it 'does not include lid property in the deserialized hash' do
+        expect(subject.keys).to contain_exactly('id', 'owner')
+        expect(subject.owner.keys).to contain_exactly('id','name')
+      end
+    end
+
+    context 'payload without lids' do
+      subject { JSONApi::Deserializer.new(payload_no_lids).deserialized_hash }
+
+      it 'includes lid property deserialized hash' do
+        expect(subject.keys).to contain_exactly('id', 'lid', 'owner')
+        expect(subject.owner.keys).to contain_exactly('id', 'lid', 'name')
+
+        expect(subject.lid).to eq(nil)
+        expect(subject.owner.lid).to eq(nil)
+      end
+
+      context 'option - false' do
+        before do
+          JSONApi::Deserializer.configure do |config|
+            config.support_lids = false
+          end
+        end
+
+        after do
+          JSONApi::Deserializer.configure do |config|
+            config.support_lids = true
+          end
+        end
+
+        it 'does not include lid property in the deserialized hash' do
+          expect(subject.keys).to contain_exactly('id', 'owner')
+          expect(subject.owner.keys).to contain_exactly('id','name')
+        end
+      end
+    end
+  end
+end

--- a/spec/jsonapi_deserializer_spec.rb
+++ b/spec/jsonapi_deserializer_spec.rb
@@ -424,7 +424,7 @@ describe JSONApi::Deserializer do
       end
     end
   end
-  
+
   context 'identification by lid' do
     context 'collection responses' do
       it 'are turned into a collection of Hashies' do


### PR DESCRIPTION
This PR adds the option to support configuration for the library & more specifically, the option to support lids or not, which by default will be `true` to ensure backwards compatibility.

Why now? We've been upgrading the stack at PopularPays in Rails and part of that is bumping up dependencies of libraries.  When we upgraded this library from 1.1.1 to 1.3.0, we had a lot of breakage because of `lid` attribute being included in the hash regardless of whether or not it was present in the payload.

We locked the library at 1.1.1 to resolve the issue, and while I think a valid argument could be the responsibility is on the application to filter the payload before persisting, I thought it might be a good opportunity to add the ability to configure the gem a bit and preserve full backwards compatibility.

These specs illustrate how the `lid` property can be included in the deserialized hash regardless of presence in the payload passed into the #deserialized_hash api:
https://github.com/PopularPays/jsonapi_deserializer/compare/optional-lids-configuration?expand=1#diff-e792552cecf844c6adfda1c0545542dffde91daf1343f330f3960ff50d5889fbR94-R103

I've added documentation for configuration in the README which could be expanded on if needed, specs to cover the various permutations of payload and conditional logic, bumped version to patch (1.3.0 -> 1.3.1) and matched on git tagging for easy perusal of the changes.  All changes are squashed into 1 commit.

Is this something of interest to the project? Thanks for considering @trek